### PR TITLE
Remove invalid keys in grammar(scope, extension)

### DIFF
--- a/scripts/update-tmLanguage.ts
+++ b/scripts/update-tmLanguage.ts
@@ -30,10 +30,11 @@ import plist from "plist";
     tmLanguageExpectationFile,
     { encoding: "utf8" }
   );
-  const plistContent = plist.build(prepareJSONforPlist(JSON.parse(content)));
+  const updatedContent = prepareJSONforPlist(JSON.parse(content));
+  const plistContent = plist.build(updatedContent);
   await fs.promises.writeFile(
     expectationsFileJSON,
-    content,
+    JSON.stringify(updatedContent, null, 2),
   );
   await fs.promises.writeFile(
     expectationsFilePlist,

--- a/syntaxes/leo.tmLanguage.json
+++ b/syntaxes/leo.tmLanguage.json
@@ -1,9 +1,9 @@
 {
   "name": "leo",
   "scopeName": "source.leo",
-  "scope": "source.leo",
-  "fileTypes": ["leo"],
-  "extension": ["leo"],
+  "fileTypes": [
+    "leo"
+  ],
   "patterns": [
     {
       "include": "#function_declaration"
@@ -26,7 +26,6 @@
     {
       "include": "#string_literal"
     },
-
     {
       "include": "#integer_literal"
     },
@@ -749,7 +748,6 @@
         {
           "include": "#line_comment"
         },
-
         {
           "include": "#integer_literal"
         },
@@ -813,7 +811,6 @@
         {
           "include": "#future_type_parameters"
         },
-
         {
           "comment": "Context Annotation",
           "name": "support.other.annotation.leo",


### PR DESCRIPTION
According to linguist warning
- Unknown keys in grammar: `source.leo` (in `syntaxes/leo.tmLanguage.json`) contains invalid keys (`scope`, `extension`)